### PR TITLE
refactor: 앨범스크린 flatlist 최적화

### DIFF
--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -61,7 +61,7 @@ export default function HomeScreen(): React.ReactElement {
         renderItem={renderItem}
         onEndReached={onLoadNext}
         maxToRenderPerBatch={20}
-        initialNumToRender={15}
+        initialNumToRender={20}
         getItemLayout={getItemLayout}
       />
     </View>
@@ -74,7 +74,7 @@ type PhotoViewProps = {
   onPress: (photo: Photo) => void;
 };
 
-const PhotoView = ({photo, onPress, selected}: PhotoViewProps) => {
+const PhotoView = React.memo(({photo, onPress, selected}: PhotoViewProps) => {
   const [loading, setLoading] = useState(true);
 
   consoleCount('render PhotoView:' + photo.id);
@@ -106,7 +106,7 @@ const PhotoView = ({photo, onPress, selected}: PhotoViewProps) => {
       )}
     </Pressable>
   );
-};
+});
 
 const styles = StyleSheet.create({
   container: {

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -62,6 +62,7 @@ export default function HomeScreen(): React.ReactElement {
         onEndReached={onLoadNext}
         maxToRenderPerBatch={20}
         initialNumToRender={20}
+        windowSize={5}
         getItemLayout={getItemLayout}
       />
     </View>


### PR DESCRIPTION
# What?
- 앨범스크린의 flatlist를 최적화 했어요.

# Why?
앨범 스크린에서 찾은 문제
- 첫화면 모든 이미지 뜨는데 4초 이상 소요됨
- 스크롤을 내리면 Blank areas 발생
- JS frame rate가 많게는 5까지 떨어짐 (반면 UI thread는 55 이상 유지)
- 즉 JS thread가 API호출 만들고, 비즈니스 로직을 처리하는 등 자원을 과도하게 쓰는 상황

## How?
JS thread가 일을 덜하게 만들 수 있는 방법으로 여러가지가 있을거 같은데요. 이 PR에선 아래를 작업했습니다.
1. keyExtractor 옵션: 리스트 아이템 추적을 유지하는데 사용. 아이템을 동적으로 추가하거나 삭제할때 도움된다고 한다.
2. getItemLayout 옵션: 아이템이 같은 width, height를 가질때 유용하다. FlatList가 비동기로 레이아웃을 계산하는 조작을 줄인다. 렌더링 된 항목의 측정을 건너뛸 수 있다.
3. renderItem에 인라인 arrow 함수 대신 선언한 함수 넘기기: 인라인 화살표 함수는 re-render 될때마다 re-create 되기 때문에 성능 이슈를 종종 야기한다.
4. PhotoView 컴포넌트에 props로 함수 넘길때 익명 함수 대신 선언한 함수 넘기기: 위와 동일
5. 이미지 출력하는 PhotoView 컴포넌트를 memo로 감싸기: 렌더링 결과를 메모이징 하고 다음 렌더링이 일어날때 props가 동일하면 메모이징된 내용을 재사용 한다.
6. windowSize의 크기를 5로 설정: 현재 뷰포트 높이를 기준으로 위 5개, 아래 5개를 그려요. default가 10인데 이미지가 많기 때문에 스크롤 내릴때 적은 개수를 그리더라도 Blank areas 를 덜 보는게 좋겠다는 생각입니다.

